### PR TITLE
Add :read-one option

### DIFF
--- a/parseclj.el
+++ b/parseclj.el
@@ -45,7 +45,9 @@ key-value pairs to specify parsing options.
 - `:lexical-preservation' Retain whitespace, comments, and
   discards.  Defaults to nil.
 - `:fail-fast' Raise an error when encountering invalid syntax.
-  Defaults to t."
+  Defaults to t.
+- `:read-one'
+  Read a single form.  Defaults to false: parse the complete input."
   (if (stringp (car string-and-options))
       (with-temp-buffer
         (insert (car string-and-options))

--- a/test/parseclj-test.el
+++ b/test/parseclj-test.el
@@ -319,6 +319,23 @@
            (new-stack (nthcdr (+ (length top-value) (length opening-token)) stack)))
       top-value)))
 
+(ert-deftest parseclj---read-one-test ()
+  (equal (parseclj-parse-clojure "(+ 1 1) foo bar" :read-one t)
+         '((:node-type . :list)
+           (:position . 1)
+           (:children ((:node-type . :symbol)
+                       (:position . 2)
+                       (:form . "+")
+                       (:value . +))
+                      ((:node-type . :number)
+                       (:position . 4)
+                       (:form . "1")
+                       (:value . 1))
+                      ((:node-type . :number)
+                       (:position . 6)
+                       (:form . "1")
+                       (:value . 1))))))
+
 (provide 'parseclj-test)
 
 ;;; parseclj-test.el ends here


### PR DESCRIPTION
Adds an option, `:read-one t`, which makes the parser behaves more like a LISP
`read` function: it will read a single form and return it.

In this case there is no extra `:root` node, the parsed node is returned
directly.