### PR TITLE
Remove the remaining a.el dependency from non-test code

### DIFF
--- a/parseclj-parser.el
+++ b/parseclj-parser.el
@@ -32,7 +32,6 @@
 
 (require 'cl-lib)
 (require 'subr-x)
-(require 'a)
 (require 'parseclj-lex)
 
 (define-error 'parseclj-parser-error "parseclj: Syntax error")


### PR DESCRIPTION
Hi maintainers!  This PR addresses the last remaining a.el dependency in the `parseclj-parser.el` file, which isn't a part of the test code.  This is my first time contributing to this project.  Please let me know if there's anything else I can do.  Thank you and keep up the good work! 