### PR TITLE
Remove the last remains of a.el, restructure requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-## 1.0.2 (2021-09-28)
+## 1.0.3 (2021-09-29)
 
 - Remove remaining a.el usage (this time for real)
 

--- a/Cask
+++ b/Cask
@@ -8,5 +8,4 @@
        "parseclj-parser.el")
 
 (development
- (depends-on "a")
  (depends-on "ert-runner"))

--- a/parseclj-alist.el
+++ b/parseclj-alist.el
@@ -1,0 +1,82 @@
+;;; parseclj-alist.el --- Clojure/EDN parser              -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017-2021  Arne Brasseur
+
+;; Author: Arne Brasseur <arne@arnebrasseur.net>
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; A shift/reduce parser for Clojure source.
+
+;;; Code:
+
+(defun parseclj-alist (&rest kvs)
+  "Create an association list from the given keys and values KVS.
+Arguments are simply provided in sequence, rather than as lists or cons cells.
+For example: (parseclj-alist :foo 123 :bar 456)"
+  ;; Emacs 27:
+  ;; (map-into kvs 'alist)
+  (mapcar (lambda (kv) (cons (car kv) (cadr kv))) (seq-partition kvs 2)))
+
+(defun parseclj-alist-assoc (coll k v)
+  "Associate a key K with a value V in the association list COLL
+
+Returns a new alist (does not mutate its argument). If an entry
+with the same key is present it will be replaced, otherwise the
+new kv-pair is added to the head of the list."
+  (if (map-contains-key coll k)
+      (mapcar (lambda (entry)
+                (if (equal (car entry) k)
+                    (cons k v)
+                  entry))
+              coll)
+    (cons (cons k v) coll)))
+
+(defun parseclj-alist-update (coll key fn &rest args)
+  "In collection COLL, at location KEY, apply FN with extra args ARGS.
+'Updates' a value in an associative collection COLL, where KEY is
+a key and FN is a function that will take the old value and any
+supplied args and return the new value, and returns a new
+structure. If the key does not exist, nil is passed as the old
+value."
+  (parseclj-alist-assoc coll
+                        key
+                        (apply #'funcall fn (map-elt coll key) args)))
+
+(defun parseclj-hash-table (&rest kvs)
+  "Create a hash table from the given keys and values KVS.
+Arguments are simply provided in sequence, rather than as lists
+or cons cells. As \"test\" for the hash table, equal is used. The
+hash table is created without extra storage space, so with a size
+equal to amount of key-value pairs, since it is assumed to be
+treated as immutable.
+For example: (parseclj-hash-table :foo 123 :bar 456)"
+  ;; Emacs 27:
+  ;; (map-into kvs 'hash-table)
+  (let* ((kv-pairs (seq-partition kvs 2))
+         (hash-map (make-hash-table :test 'equal :size (length kv-pairs))))
+    (seq-do (lambda (pair)
+              (puthash (car pair) (cadr pair) hash-map))
+            kv-pairs)
+    hash-map))
+
+(provide 'parseclj-alist)
+
+;;; parseclj-alist.el ends here

--- a/parseclj-ast.el
+++ b/parseclj-ast.el
@@ -30,6 +30,7 @@
 (require 'seq)
 (require 'subr-x)
 (require 'parseclj-lex)
+(require 'parseclj-alist)
 
 ;; AST helper functions
 

--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(require 'parseclj-alist)
+
 (defvar parseclj-lex--leaf-tokens '(:whitespace
                                     :comment
                                     :symbolic-value

--- a/parseclj-parser.el
+++ b/parseclj-parser.el
@@ -3,9 +3,6 @@
 ;; Copyright (C) 2017-2021  Arne Brasseur
 
 ;; Author: Arne Brasseur <arne@arnebrasseur.net>
-;; Keywords: lisp
-;; Package-Requires: ((emacs "25"))
-;; Version: 0.2.0
 
 ;; This file is not part of GNU Emacs.
 
@@ -33,6 +30,7 @@
 (require 'cl-lib)
 (require 'subr-x)
 (require 'parseclj-lex)
+(require 'parseclj-alist)
 
 (define-error 'parseclj-parser-error "parseclj: Syntax error")
 

--- a/parseclj.el
+++ b/parseclj.el
@@ -5,7 +5,7 @@
 ;; Author: Arne Brasseur <arne@arnebrasseur.net>
 ;; Keywords: lisp clojure edn parser
 ;; Package-Requires: ((emacs "25"))
-;; Version: 1.0.2
+;; Version: 1.0.3
 
 ;; This file is not part of GNU Emacs.
 
@@ -33,58 +33,9 @@
 (require 'map)
 (require 'seq)
 
-(defun parseclj-alist (&rest kvs)
-  "Create an association list from the given keys and values KVS.
-Arguments are simply provided in sequence, rather than as lists or cons cells.
-For example: (parseclj-alist :foo 123 :bar 456)"
-  ;; Emacs 27:
-  ;; (map-into kvs 'alist)
-  (mapcar (lambda (kv) (cons (car kv) (cadr kv))) (seq-partition kvs 2)))
-
 (require 'parseclj-parser)
 (require 'parseclj-ast)
-
-(defun parseclj-hash-table (&rest kvs)
-  "Create a hash table from the given keys and values KVS.
-Arguments are simply provided in sequence, rather than as lists
-or cons cells. As \"test\" for the hash table, equal is used. The
-hash table is created without extra storage space, so with a size
-equal to amount of key-value pairs, since it is assumed to be
-treated as immutable.
-For example: (parseclj-hash-table :foo 123 :bar 456)"
-  ;; Emacs 27:
-  ;; (map-into kvs 'hash-table)
-  (let* ((kv-pairs (seq-partition kvs 2))
-         (hash-map (make-hash-table :test 'equal :size (length kv-pairs))))
-    (seq-do (lambda (pair)
-              (puthash (car pair) (cadr pair) hash-map))
-            kv-pairs)
-    hash-map))
-
-(defun parseclj-alist-assoc (coll k v)
-  "Associate a key K with a value V in the association list COLL
-
-Returns a new alist (does not mutate its argument). If an entry
-with the same key is present it will be replaced, otherwise the
-new kv-pair is added to the head of the list."
-  (if (map-contains-key coll k)
-      (mapcar (lambda (entry)
-                (if (equal (car entry) k)
-                    (cons k v)
-                  entry))
-              coll)
-    (cons (cons k v) coll)))
-
-(defun parseclj-alist-update (coll key fn &rest args)
-  "In collection COLL, at location KEY, apply FN with extra args ARGS.
-'Updates' a value in an associative collection COLL, where KEY is
-a key and FN is a function that will take the old value and any
-supplied args and return the new value, and returns a new
-structure. If the key does not exist, nil is passed as the old
-value."
-  (parseclj-alist-assoc coll
-                        key
-                        (apply #'funcall fn (map-elt coll key) args)))
+(require 'parseclj-alist)
 
 (defun parseclj-parse-clojure (&rest string-and-options)
   "Parse Clojure source to AST.

--- a/test/parseclj-ast-test.el
+++ b/test/parseclj-ast-test.el
@@ -27,7 +27,6 @@
 
 ;;; Code
 
-(require 'a)
 (require 'ert)
 (require 'parseclj-ast)
 
@@ -46,7 +45,7 @@
                      (with-temp-buffer
                        (insert ,(map-elt data :source))
                        (goto-char 1)
-                       (should (a-equal (parseclj-parse-clojure) ',(map-elt data :ast)))))))))
+                       (should (equal (parseclj-parse-clojure) ',(map-elt data :ast)))))))))
         parseclj-test-data)))
 
 (defmacro define-parseclj-ast-roundtrip-tests ()
@@ -59,7 +58,10 @@
                 (let ((test-name (intern (concat "parseclj-ast-rountrip:" name))))
                   `(ert-deftest ,test-name ()
                      :tags '(parseclj-ast-rountrip)
-                     (should (a-equal (parseclj-parse-clojure (parseclj-unparse-clojure-to-string ',(map-elt data :ast))) ',(map-elt data :ast))))))))
+                     (should (equal (parseclj-parse-clojure (parseclj-unparse-clojure-to-string
+                                                             ',(map-elt data :ast)))
+                                    ',(or (map-elt data :roundtrip-ast)
+                                          (map-elt data :ast)))))))))
         parseclj-test-data)))
 
 (define-parseclj-ast-roundtrip-tests)

--- a/test/parseclj-test-data.el
+++ b/test/parseclj-test-data.el
@@ -272,7 +272,20 @@
                                             ((:node-type . :number)
                                              (:position . 10)
                                              (:form . "12")
-                                             (:value . 12)))))))))
+                                             (:value . 12))))))))
+        ;; After round-tripping the position of the "12" is no longer the same
+        :roundtrip-ast '((:node-type . :root)
+                         (:position . 1)
+                         (:children . (((:node-type . :list)
+                                        (:position . 1)
+                                        (:children . (((:node-type . :number)
+                                                       (:position . 2)
+                                                       (:form . "10")
+                                                       (:value . 10))
+                                                      ((:node-type . :number)
+                                                       (:position . 5)
+                                                       (:form . "12")
+                                                       (:value . 12)))))))))
 
 
        "tag-1"


### PR DESCRIPTION

Remove the last calls of a-equals from the tests, so we can truly drop this.
Extract the alist/hash-map helpers in a separate file so we can require them
everywhere we need them.

