### PR TITLE
Add support for big ints

### DIFF
--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -250,6 +250,10 @@ S goes through three transformations:
     (when (eq (char-after (point)) ?M)
       (right-char))
 
+    ;; trailing N clojure.lang.BigInt
+    (when (eq (char-after (point)) ?N)
+      (right-char))
+
     (let ((char (char-after (point))))
       (if (and char (or (and (<= ?a char) (<= char ?z))
                         (and (<= ?A char) (<= char ?Z))

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -46,6 +46,13 @@
                                          (:pos . 1)))))
 
   (with-temp-buffer
+    (insert "123N")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) '((:token-type . :number)
+                                         (:form . "123N")
+                                         (:pos . 1)))))
+
+  (with-temp-buffer
     (insert "123e34M")
     (goto-char 1)
     (should (equal (parseclj-lex-next) '((:token-type . :number)


### PR DESCRIPTION
Hello,

trying to parse a Clojure big integer fails at the moment with an
invalid token error. This PR adds support for parsing Clojure's
big integers.

This is how Clojure does it:
```
user=> (clojure.edn/read-string "1N")
1N
```

This is how it fails at the moment in Elisp:
```
Debugger entered--Lisp error: (parseclj-parser-error "Invalid token at 1: \"1N\"")
  parseclj--error("Invalid token at %s: %S" 1 "1N")
  ....
```

This is how Elisp parses a big integer using this PR:

```
(parseclj-parse-clojure "1N")
((:node-type . :root)
 (:position . 1)
 (:children
  ((:node-type . :number)
   (:position . 1)
   (:form . "1N")
   (:value . 1))))
```
Would you like to support this and merge the PR?

Thanks, Roman.