### PR TITLE
Add support for ratio

### DIFF
--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -67,6 +67,13 @@
                                          (:pos . 1)))))
 
   (with-temp-buffer
+    (insert "12/34")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) '((:token-type . :number)
+                                         (:form . "12/34")
+                                         (:pos . 1)))))
+
+  (with-temp-buffer
     (insert "#?(:clj 1 :cljs 2)")
     (goto-char 1)
     (should (equal (parseclj-lex-next)

--- a/test/parseclj-test-data.el
+++ b/test/parseclj-test-data.el
@@ -211,6 +211,18 @@
                               (:form . ":foo-bar")
                               (:value . :foo-bar))))))
 
+       "ratio"
+       (parseclj-alist
+        :tags '(:edn-roundtrip)
+        :source "12/34"
+        :edn '(0.35294117647058826)
+        :ast '((:node-type . :root)
+               (:position . 1)
+               (:children ((:node-type . :number)
+                           (:position . 1)
+                           (:form . "12/34")
+                           (:value . 0.35294117647058826)))))
+
        "vector"
        (parseclj-alist
         :tags '(:edn-roundtrip)

--- a/test/parseclj-unparse-test.el
+++ b/test/parseclj-unparse-test.el
@@ -130,6 +130,16 @@
                                    (:form . ":foo-bar")
                                    (:value . :foo-bar)))))))))
 
+(ert-deftest parseclj-unparse-clojure-ratio ()
+  (should (equal "12/34"
+                 (parseclj-unparse-clojure-to-string
+                  '((:node-type . :root)
+                    (:position . 1)
+                    (:children ((:node-type . :number)
+                                (:position . 1)
+                                (:form . "12/34")
+                                (:value . 0.35294117647058826))))))))
+
 (ert-deftest parseclj-unparse-clojure-vector ()
   (should (equal "[123]"
                  (parseclj-unparse-clojure-to-string


### PR DESCRIPTION
Hi @plexus,

This PR adds support for clojure.lang.Ratio fixing issue #24.

Since Elisp does not have a ratio type, a Clojure ratio is converted
to Elisp using this expression:

``` emacs-lisp
(/ numerator (float denominator)).
```

We are calling float on the denominator to perform floating point
arithmetic, instead of the default integer arithmetic.

I was thinking about introducing a new tagged type called :ratio, but
since clojure.lang.Ratio is a sub class of Number in Java as well, I
extended the lexer and parser that handles numbers.

``` java
public class Ratio extends Number {}
```

WDYT?
