### PR TITLE
add `|` to the list of valid symbol chars

### DIFF
--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -29,6 +29,20 @@
 
 (require 'parseclj-alist)
 
+(defcustom parseclj-lex-symbol-special-chars
+  '(?. ?* ?+ ?! ?- ?_ ?? ?$ ?% ?& ?= ?< ?> ?/ ?')
+  "The list of characters that can consitute a symbol or keyword's name.
+
+Please note that Clojure might at runtime accept keywords with
+more constituent characters than those found in the default value
+of this variable (which is the officially supported list), but
+the end result should be treated as undefined.  This could be the
+case for example when keywordized maps are created from external
+sources without keyword validation.  Change this value at your
+own risk."
+  :type 'sexp
+  :group 'parseclj)
+
 (defvar parseclj-lex--leaf-tokens '(:whitespace
                                     :comment
                                     :symbolic-value
@@ -303,7 +317,7 @@ alphabetic characters only.  ALPHA-ONLY ensures this behavior."
   (not (not (and char
                  (or (and (<= ?a char) (<= char ?z))
                      (and (<= ?A char) (<= char ?Z))
-                     (and (not alpha-only) (member char '(?. ?* ?+ ?! ?- ?_ ?? ?$ ?% ?& ?= ?< ?> ?/ ?'))))))))
+                     (and (not alpha-only) (member char parseclj-lex-symbol-special-chars)))))))
 
 (defun parseclj-lex-symbol-rest-p (char)
   "Return t if CHAR is a valid character in a symbol.

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -309,7 +309,12 @@
   (should (equal (parseclj-lex-symbol-rest-p ?A) t))
   (should (equal (parseclj-lex-symbol-rest-p ?.) t))
   (should (equal (parseclj-lex-symbol-rest-p ?~) nil))
-  (should (equal (parseclj-lex-symbol-rest-p ? ) nil)))
+  (should (equal (parseclj-lex-symbol-rest-p ? ) nil))
+
+  (should (equal (parseclj-lex-symbol-rest-p ?|) nil))
+  (let ((parseclj-lex-symbol-special-chars (cons  ?| parseclj-lex-symbol-special-chars)))
+    (should (equal (parseclj-lex-symbol-rest-p ?|) t)))
+  (should (equal (parseclj-lex-symbol-rest-p ?|) nil)))
 
 (ert-deftest parseclj-lex-test-get-symbol-at-point ()
   (with-temp-buffer


### PR DESCRIPTION
Hi,

would you please consider path to add `|` to the list of valid symbol chars. 

Fixes #38.

Also added a test entry.

Thanks.